### PR TITLE
fix: corrected IP Addresses link in README and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You may want to take a look at other articles too:
     - [Turing Test](https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/logic/Turing_Test.md)
 - Networking
     - [Blockchain](https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/Networking/Blockchain.md)
-    - [IP Addresses](https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/Networking/IP_addresses.md)
+    - [IP Addresses](guides/Networking/IP_addresses.md)
 - Open Source Software
     - [Open Source Software](https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/Open_Source_Software/OpenSourceSoftware.md)
 - Programming Paradigm

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 				<p class="links_header">Networking
 					<ul>
 						<li><a class="l_elements" href="https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/Networking/Blockchain.md">Blockchain</a></li>
-						<li><a class="l_elements" href="https://github.com/the-ethan-hunt/first-timers-guide/blob/master/guides/Networking/IP_addresses.md">IP Addresses</a></li>
+						<li><a class="l_elements" href="guides/Networking/IP_addresses.md">IP Addresses</a></li>
 					</ul>
 				</p>
 				<p class="links_header">Open Source Software


### PR DESCRIPTION
## 📌 Description
Fixed broken IP Addresses link in README.md and index.html.

## 🚀 Changes Made
- Updated README.md to use correct relative path
- Fixed link in index.html
- Ensured IP Addresses page opens correctly

## 🧪 How to Test
- Open README
- Click IP Addresses link
- Verify it opens without 404